### PR TITLE
Compatibility Fix for Python < 2.7

### DIFF
--- a/gelfclient/client.py
+++ b/gelfclient/client.py
@@ -7,8 +7,8 @@ import sys
 import copy
 from datetime import datetime
 
-string_types = str   if sys.version_info.major == 3 else basestring
-xrange       = range if sys.version_info.major == 3 else xrange
+string_types = str   if sys.version_info[0] == 3 else basestring
+xrange       = range if sys.version_info[0] == 3 else xrange
 
 class UdpClient():
 


### PR DESCRIPTION
sys.version_info.major was added in Python 2.7. For compatibility with Python < 2.7 sys.version_info[0] should be used.