### PR TITLE
Fix compatibility with CentOS 7 (it have 1.9 six version)

### DIFF
--- a/gelfclient/__init__.py
+++ b/gelfclient/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 from .client import UdpClient

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ setup(
         "Topic :: System :: Logging"
     ],
     setup_requires= [
-        'six>=1.10'
+        'six>=1.9'
     ],
     install_requires=[
-        'six>=1.10',
+        'six>=1.9',
     ],
      test_suite='gelfclient.tests',
 )


### PR DESCRIPTION
Hello. This small fix for compatibility with CentOS 7. It have six==1.9 version and python-gelfclient==0.0.5 installation fails.